### PR TITLE
apply scope values onEnd while dragstop is active

### DIFF
--- a/slider.coffee
+++ b/slider.coffee
@@ -159,6 +159,7 @@ sliderDirective = ($timeout) ->
               scope[high] = scope.local[high]
               scope[low] = scope.local[low]
             currentRef = ref
+            scope.$apply()
           onMove = (event) ->
             eventX = event.clientX || event.touches[0].clientX
             newOffset = eventX - element[0].getBoundingClientRect().left - handleHalfWidth


### PR DESCRIPTION
While dragstop is active scope values should be applied in onEnd event as well.
