### PR TITLE
fixed bug that causes number format error in angular 1.3.1

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -261,7 +261,7 @@
                   newValue = roundStep(newValue, parseInt(scope.precision), parseFloat(scope.step), parseFloat(scope.floor));
                   scope.local[currentRef] = newValue;
                   if (!scope.dragstop) {
-                    scope[currentRef] = newValue;
+                    scope[currentRef] = parseFloat(newValue);
                   }
                   setPointers();
                   return scope.$apply();


### PR DESCRIPTION
When moving the slider, I'd get a number format error as it updated the scope. This seems to fix it.
