### PR TITLE
Force bubbles to be shown at low or high value when model is out of min ...

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -183,13 +183,13 @@
               setPointers = function() {
                 var newHighValue, newLowValue;
                 offset(ceilBub, pixelize(barWidth - width(ceilBub)));
-                newLowValue = percentValue(scope.local[low]);
+                newLowValue = Math.min(100,Math.max(0,percentValue(scope.local[low])));
                 offset(minPtr, percentToOffset(newLowValue));
                 offset(lowBub, pixelize(offsetLeft(minPtr) - (halfWidth(lowBub)) + handleHalfWidth));
                 offset(selection, pixelize(offsetLeft(minPtr) + handleHalfWidth));
                 switch (true) {
                   case range:
-                    newHighValue = percentValue(scope.local[high]);
+                    newHighValue = Math.min(100,Math.max(0,percentValue(scope.local[high])));
                     offset(maxPtr, percentToOffset(newHighValue));
                     offset(highBub, pixelize(offsetLeft(maxPtr) - (halfWidth(highBub)) + handleHalfWidth));
                     return selection.css({


### PR DESCRIPTION
When data is binding with model, and if model low and high values exceed min and max values, bubbles are outside range. This fix let low/high bubble to be shown at min/max value. M odel can have lower or higher value than Max (ex: an user change an input value, which is outside range, but model is binding with  model in slider).