### PR TITLE
Update slider.js

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -99,7 +99,7 @@
         ngModelLow: '=?',
         ngModelHigh: '=?'
       },
-      template: '<div class="bar"><div class="selection"></div></div>\n<div class="handle low"></div><div class="handle high"></div>\n<div class="bubble limit low">{{ values.length ? values[floor || 0] : floor }}</div>\n<div class="bubble limit high">{{ values.length ? values[ceiling || values.length - 1] : ceiling }}</div>\n<div class="bubble value low">{{ values.length ? values[local.ngModelLow || local.ngModel || 0] : local.ngModelLow || local.ngModel || 0 }}</div>\n<div class="bubble value high">{{ values.length ? values[local.ngModelHigh] : local.ngModelHigh }}</div>',
+      template: '<div class="bar"><div class="selection"></div></div>\n<div class="handle low"></div><div class="handle high"></div>\n<div class="bubble limit low">{{ values.length ? ( values[floor || 0] || floor ) : floor }}</div>\n<div class="bubble limit high">{{ values.length ? ( values[ceiling || values.length - 1] || ceiling ) : ceiling }}</div>\n<div class="bubble value low">{{ values.length ? ( values[local.ngModelLow || local.ngModel].toString() || local.ngModelLow.toString() || local.ngModel.toString() ) : local.ngModelLow.toString() || local.ngModel.toString()}}</div>\n<div class="bubble value high">{{ values.length ? ( values[local.ngModelHigh].toString() || local.ngModelHigh.toString() ) : local.ngModelHigh.toString() }}</div>',
       compile: function(element, attributes) {
         var high, low, range, watchables;
         range = (attributes.ngModel == null) && (attributes.ngModelLow != null) && (attributes.ngModelHigh != null);


### PR DESCRIPTION
Added string conversion to ternary operator for bubble display.  This fixes the issue of the lower handle value not being displayed, as the comparison was looking at numerical zero vs an empty string, which both evaluate to false, resulting in the second value being returned.  By converting to string, when the value is '0' this is selected over the empty string.