### PR TITLE
preserve other's event listeners.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,5 +14,5 @@
   },
   "author": "PopSugar",
   "license": "MIT",
-  "readmeFilename": "README.md",
+  "readmeFilename": "README.md"
 }

--- a/dist/slider.js
+++ b/dist/slider.js
@@ -221,8 +221,8 @@
                 onEnd = function() {
                   bubble.removeClass('active');
                   handle.removeClass('active');
-                  ngDocument.unbind(events.move);
-                  ngDocument.unbind(events.end);
+                  ngDocument.unbind(events.move, onMove);
+                  ngDocument.unbind(events.end, onEnd);
                   if (scope.dragstop) {
                     scope[high] = scope.local[high];
                     scope[low] = scope.local[low];

--- a/slider.coffee
+++ b/slider.coffee
@@ -156,8 +156,8 @@ sliderDirective = ($timeout) ->
           onEnd = ->
             bubble.removeClass 'active'
             handle.removeClass 'active'
-            ngDocument.unbind events.move
-            ngDocument.unbind events.end
+            ngDocument.unbind events.move, onMove
+            ngDocument.unbind events.end, onEnd
             if scope.dragstop
               scope[high] = scope.local[high]
               scope[low] = scope.local[low]


### PR DESCRIPTION
`angular-slider` directive unbinds all `mousemove` and `mouseup` event
listeners from the document when user finish sliding, thus effectively
unsubscribe rest of the code from aforementioned events. In order to
preserve external listeners only own event handlers are unbinded.

bug can be reproduced here - https://jsfiddle.net/8c31mpyd/
